### PR TITLE
Handle api contact method not allowed

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -30,7 +30,18 @@ const Contact = () => {
     setIsSubmitting(true)
     setStatus({ type: null, message: '' })
     try {
-      const API_BASE = (import.meta.env.VITE_API_BASE || '').replace(/\/$/, '') || '/api'
+      const apiBaseRaw = (import.meta.env.VITE_API_BASE || '').trim()
+      const API_BASE = apiBaseRaw ? apiBaseRaw.replace(/\/$/, '') : null
+
+      if (!API_BASE) {
+        const mailtoSubject = encodeURIComponent(`[Portfolio] ${formData.subject} (from ${formData.name})`)
+        const mailtoBody = encodeURIComponent(`Name: ${formData.name}\nEmail: ${formData.email}\n\n${formData.message}`)
+        window.location.href = `mailto:tedionabera@gmail.com?subject=${mailtoSubject}&body=${mailtoBody}`
+        setStatus({ type: 'success', message: 'Opening your email client…' })
+        setFormData({ name: '', email: '', subject: '', message: '' })
+        return
+      }
+
       const res = await fetch(`${API_BASE}/contact`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Implement a `mailto:` fallback for the contact form to function on GitHub Pages without a dedicated backend.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1126536-8a35-435f-835a-de7de8397a8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1126536-8a35-435f-835a-de7de8397a8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

